### PR TITLE
Add initial color validation model notebook

### DIFF
--- a/ValidationModelV1.ipynb
+++ b/ValidationModelV1.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b417d910-e7e2-4c91-b24e-e5a6d151ab2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.keras.preprocessing.image import ImageDataGenerator\n",
+    "from tensorflow.keras.applications import ResNet50\n",
+    "from tensorflow.keras.models import Model\n",
+    "from tensorflow.keras.layers import Dense, Dropout, GlobalAveragePooling2D, Input, Concatenate\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b05e7564-2ad1-4387-8521-b0fedca633e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET_PATH = \"imagesDataset\"\n",
+    "CLASSES = [\"in_range\", \"out_range\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "354d84f9-2f9c-4cc1-b856-b564cb3c1329",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocess_image(image_path, target_size=(224, 224)):\n",
+    "    img = tf.keras.preprocessing.image.load_img(image_path, target_size=target_size)\n",
+    "    img_array = tf.keras.preprocessing.image.img_to_array(img)\n",
+    "    img_array = tf.keras.applications.resnet50.preprocess_input(img_array)\n",
+    "    return img_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5a8e1e4-846b-45a2-909f-13a99ddee2eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_dataset(dataset_path):\n",
+    "    images = []\n",
+    "    labels = []\n",
+    "    categories = [(\"medium_cherry\", \"in_range_normal\", 0),\n",
+    "                  (\"medium_cherry\", \"out_range\", 1),\n",
+    "                  (\"graphite_walnut\", \"in_range_normal\", 0),\n",
+    "                  (\"graphite_walnut\", \"out_range\", 1)]\n",
+    "    \n",
+    "    for wood_type, condition, label in categories:\n",
+    "        condition_path = os.path.join(dataset_path, wood_type, condition)\n",
+    "        for subdir in os.listdir(condition_path):\n",
+    "            subdir_path = os.path.join(condition_path, subdir)\n",
+    "            for img_file in os.listdir(subdir_path):\n",
+    "                img_path = os.path.join(subdir_path, img_file)\n",
+    "                img_array = preprocess_image(img_path)\n",
+    "                images.append(img_array)\n",
+    "                labels.append(label)\n",
+    "    \n",
+    "    images = np.array(images)\n",
+    "    labels = np.array(labels)\n",
+    "    return images, labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c213adf5-343a-4d4e-8f66-4d74389e28e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images, labels = load_dataset(DATASET_PATH)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c9fca74-2bd0-4c91-8edf-3b0f77887340",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train, X_test, y_train, y_test = train_test_split(images, labels, test_size=0.2, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "686b7dd8-a251-4c9c-b4b8-11ca8e33f611",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_model():\n",
+    "    # Pre-trained ResNet50 as feature extractor\n",
+    "    base_model = ResNet50(weights=\"imagenet\", include_top=False, input_shape=(224, 224, 3))\n",
+    "    base_model.trainable = False  # Freeze pre-trained layers\n",
+    "\n",
+    "    # Feature extraction and classification head\n",
+    "    x = GlobalAveragePooling2D()(base_model.output)\n",
+    "    x = Dense(256, activation=\"relu\")(x)\n",
+    "    x = Dropout(0.5)(x)\n",
+    "    output = Dense(1, activation=\"sigmoid\")(x)\n",
+    "\n",
+    "    # Build the model\n",
+    "    model = Model(inputs=base_model.input, outputs=output)\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22b891e2-8367-4e1a-b93a-3000100a479c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = build_model()\n",
+    "model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=0.001),\n",
+    "              loss=\"binary_crossentropy\",\n",
+    "              metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9001355-b03d-4b19-a54e-382241e4b86c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datagen = ImageDataGenerator(rotation_range=15, width_shift_range=0.1, height_shift_range=0.1,\n",
+    "                             horizontal_flip=True, vertical_flip=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46f3feba-f481-4e95-bc31-c9e5e38a2c1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BATCH_SIZE = 32\n",
+    "EPOCHS = 10\n",
+    "\n",
+    "history = model.fit(datagen.flow(X_train, y_train, batch_size=BATCH_SIZE),\n",
+    "                    validation_data=(X_test, y_test),\n",
+    "                    epochs=EPOCHS,\n",
+    "                    steps_per_epoch=len(X_train) // BATCH_SIZE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b61de32-0997-4587-b855-eb25f782b198",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss, accuracy = model.evaluate(X_test, y_test)\n",
+    "print(f\"Test Loss: {loss}\")\n",
+    "print(f\"Test Accuracy: {accuracy}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a64584e-1681-4d9b-84b5-b5247dcde46b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.save(\"color_validation_model.h5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0692f57e-43e4-4927-8591-82ddede7d6ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalize_sample(reference_img, sample_img):\n",
+    "    # Calculate mean and standard deviation of reference image\n",
+    "    ref_mean, ref_std = np.mean(reference_img), np.std(reference_img)\n",
+    "    sample_mean, sample_std = np.mean(sample_img), np.std(sample_img)\n",
+    "\n",
+    "    # Normalize the sample image to match the reference\n",
+    "    normalized_sample = (sample_img - sample_mean) / sample_std * ref_std + ref_mean\n",
+    "    return np.clip(normalized_sample, 0, 255)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfad54ce-5912-43d4-9224-6d1e8c1fa946",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def validate_sample(reference_path, sample_path, model):\n",
+    "    ref_img = preprocess_image(reference_path)\n",
+    "    sample_img = preprocess_image(sample_path)\n",
+    "\n",
+    "    normalized_sample = normalize_sample(ref_img, sample_img)\n",
+    "    prediction = model.predict(np.expand_dims(normalized_sample, axis=0))\n",
+    "    confidence = prediction[0][0]\n",
+    "\n",
+    "    result = \"in_range\" if confidence >= 0.5 else \"out_range\"\n",
+    "    return result, confidence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0ab43e5-0e9c-4ee8-90c9-8251cbc0a43d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reference_image = \"imagesDataset/medium_cherry/in_range_normal/example.jpg\"\n",
+    "sample_image = \"imagesDataset/medium_cherry/out_range/extreme_light/example.jpg\"\n",
+    "result, confidence = validate_sample(reference_image, sample_image, model)\n",
+    "print(f\"Result: {result}, Confidence: {confidence:.2f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request adds a Jupyter Notebook for the initial implementation of the color validation model for the Steelcase Junior Design project. The notebook includes:
- Dataset handling for the imagesDataset directory structure.
- A ResNet50-based transfer learning model for classifying in-range vs. out-range veneer samples.
- Lighting normalization logic using a validated reference sample.
- Training, evaluation, and testing scripts for binary classification tasks.

Purpose:
- To provide a foundational framework for the color validation model that can be further iterated and refined.