### PR TITLE
Added Save Reports to Analyze Button

### DIFF
--- a/TrueHue/config.js
+++ b/TrueHue/config.js
@@ -2,7 +2,7 @@ import Constants from "expo-constants";
 
 // Get the API URL from environment variables or use default
 
-const API_URL = "http://10.91.4.153:3050";
+const API_URL = "http://localhost:3050";
 
 /*
 const API_URL =


### PR DESCRIPTION
## ✨ PR Title:
**Add Save Report Button to Analysis Data Card with Unified Save Functionality**

---

## 📌 Summary:

This PR introduces a **"Save Report" button to the Analysis Data Card**, enabling users to persist analysis results to Firebase. It also **refactors the `saveReport` function** to handle both report and analysis data using a shared logic path.

---

## 🛠️ Key Changes:

- **Refactored `saveReport` function**:
  - Added `isAnalysis` parameter (default: `false`)
  - Unified logic for uploading the image, formatting the document, and saving to Firestore
  - Conditional data handling for report vs. analysis results

- **UI Enhancements**:
  - Added a **"Save Report" button** to the bottom of the Analysis Data Card
  - Matched styling to the existing Report Data Card button
  - Used `onPress={() => saveReport(true)}` to trigger the correct save behavior

- **Maintained backward compatibility**:
  - Existing Report Data Card save button now explicitly calls `saveReport(false)`

---

## ✅ Benefits:

- Users can now **save analysis results** directly from the Analysis Data Card
- Promotes **code reuse** and eliminates redundant save logic
- Maintains a **consistent UI/UX** across different types of results
- Prepares the app for easier future extensibility (e.g., saving other data types)

---

## 🔍 Test Coverage:

- ✅ Manual testing for both save buttons (report and analysis)
- ✅ Firebase upload and Firestore document creation validated
- ✅ Alert messages and error logs confirmed functional
